### PR TITLE
feat(backend): add admin panel API, user roles, and integration tests

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,17 +9,20 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
 	modernc.org/sqlite v1.50.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
@@ -30,6 +33,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/backend/internal/auth/admin_middleware.go
+++ b/backend/internal/auth/admin_middleware.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/models"
+)
+
+// RequireAdmin запрещает доступ всем кроме пользователей с ролью admin.
+// Должен использоваться после Middleware — роль уже лежит в контексте.
+func RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		role, ok := UserRoleFromContext(r.Context())
+		if !ok || role != models.UserRoleAdmin {
+			http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -4,14 +4,21 @@ import (
 	"context"
 	"net/http"
 	"strings"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/models"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/repository"
 )
 
 type contextKey string
 
-const UserIDKey contextKey = "user_id"
+const (
+	UserIDKey   contextKey = "user_id"
+	UserRoleKey contextKey = "user_role"
+)
 
-// Middleware проверяет JWT в заголовке Authorization: Bearer <token>
-func Middleware(secret string) func(http.Handler) http.Handler {
+// Middleware проверяет JWT, убеждается что пользователь не заблокирован,
+// и кладёт user_id + role в контекст запроса.
+func Middleware(secret string, users *repository.UserRepository) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
@@ -27,7 +34,23 @@ func Middleware(secret string) func(http.Handler) http.Handler {
 				return
 			}
 
-			ctx := context.WithValue(r.Context(), UserIDKey, claims.UserID)
+			// Проверяем пользователя в БД — актуальный статус блокировки и роль
+			user, err := users.FindByID(claims.UserID)
+			if err != nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
+			if user.IsBlocked {
+				http.Error(w, `{"error":"account blocked"}`, http.StatusForbidden)
+				return
+			}
+
+			// Обновляем last_seen_at асинхронно — не блокируем запрос
+			go users.UpdateLastSeen(user.ID) //nolint:errcheck
+
+			ctx := context.WithValue(r.Context(), UserIDKey, user.ID)
+			ctx = context.WithValue(ctx, UserRoleKey, user.Role)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -37,4 +60,10 @@ func Middleware(secret string) func(http.Handler) http.Handler {
 func UserIDFromContext(ctx context.Context) (int64, bool) {
 	id, ok := ctx.Value(UserIDKey).(int64)
 	return id, ok
+}
+
+// UserRoleFromContext извлекает роль пользователя из контекста запроса.
+func UserRoleFromContext(ctx context.Context) (models.UserRole, bool) {
+	role, ok := ctx.Value(UserRoleKey).(models.UserRole)
+	return role, ok
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/spf13/viper"
 	"log"
 	"strings"
+
+	"github.com/spf13/viper"
 )
 
 type Config struct {
@@ -16,6 +17,10 @@ type Config struct {
 	JWTSecret      string
 	SelfHosted     bool
 	ServerSecret   string
+
+	// CORS
+	CORSAllowAll bool     // true — разрешаем любой origin (только для dev)
+	CORSOrigins  []string // список разрешённых origins для продакшена
 
 	// OAuth (читаются только из env — содержат секреты)
 	GoogleClientID  string
@@ -39,12 +44,13 @@ func Load() *Config {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
-	// Дефолты (если нет ни yaml, ни env)
+	// Дефолты
 	viper.SetDefault("server.port", 8080)
 	viper.SetDefault("storage.driver", "sqlite")
 	viper.SetDefault("storage.sqlite.path", "./subradar.db")
 	viper.SetDefault("auth.jwt_secret", "change-me-in-production")
 	viper.SetDefault("auth.self_hosted", false)
+	viper.SetDefault("cors.allow_all", false) // в продакшене false, в dev можно true
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -66,6 +72,9 @@ func Load() *Config {
 		JWTSecret:    viper.GetString("auth.jwt_secret"),
 		SelfHosted:   viper.GetBool("auth.self_hosted"),
 		ServerSecret: viper.GetString("auth.server_secret"),
+
+		CORSAllowAll: viper.GetBool("cors.allow_all"),
+		CORSOrigins:  viper.GetStringSlice("cors.origins"),
 
 		GoogleClientID:  viper.GetString("GOOGLE_CLIENT_ID"),
 		AppleTeamID:     viper.GetString("APPLE_TEAM_ID"),

--- a/backend/internal/db/migrations/000003_admin.down.sql
+++ b/backend/internal/db/migrations/000003_admin.down.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- Откат миграции 000003
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Откатываем categories — возвращаем NOT NULL на user_id,
+--    убираем is_system
+-- ------------------------------------------------------------
+
+CREATE TABLE categories_old (
+                                id         TEXT    PRIMARY KEY,
+                                user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                                name       TEXT    NOT NULL,
+                                icon       TEXT    NOT NULL DEFAULT 'ellipsis.circle',
+                                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                UNIQUE(user_id, name)
+);
+
+-- Системные категории (user_id IS NULL) при откате теряются — это ожидаемо
+INSERT INTO categories_old (id, user_id, name, icon, created_at)
+SELECT                       id, user_id, name, icon, created_at
+FROM categories
+WHERE user_id IS NOT NULL;
+
+DROP TABLE categories;
+ALTER TABLE categories_old RENAME TO categories;
+
+CREATE INDEX IF NOT EXISTS idx_categories_user_id ON categories(user_id);
+
+-- ------------------------------------------------------------
+-- 2. Откатываем колонки users
+--    SQLite не поддерживает DROP COLUMN до версии 3.35.0.
+--    Пересоздаём таблицу без новых полей.
+-- ------------------------------------------------------------
+
+CREATE TABLE users_old (
+                           id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                           email         TEXT    NOT NULL UNIQUE,
+                           password_hash TEXT    NOT NULL DEFAULT '',
+                           provider      TEXT    NOT NULL DEFAULT 'local',
+                           provider_id   TEXT    NOT NULL DEFAULT '',
+                           created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO users_old (id, email, password_hash, provider, provider_id, created_at)
+SELECT                  id, email, password_hash, provider, provider_id, created_at
+FROM users;
+
+DROP TABLE users;
+ALTER TABLE users_old RENAME TO users;

--- a/backend/internal/db/migrations/000003_admin.up.sql
+++ b/backend/internal/db/migrations/000003_admin.up.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- Миграция 000003: поддержка ролей и системных категорий
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Расширяем таблицу users
+-- ------------------------------------------------------------
+
+ALTER TABLE users ADD COLUMN role         TEXT     NOT NULL DEFAULT 'user';
+ALTER TABLE users ADD COLUMN is_blocked   INTEGER  NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN blocked_at   DATETIME;
+ALTER TABLE users ADD COLUMN blocked_reason TEXT;
+ALTER TABLE users ADD COLUMN display_name TEXT     NOT NULL DEFAULT '';
+ALTER TABLE users ADD COLUMN last_seen_at DATETIME;
+
+-- ------------------------------------------------------------
+-- 2. Пересоздаём categories — нужно сделать user_id nullable
+--    (системные категории не принадлежат никакому пользователю)
+--    SQLite не поддерживает ALTER COLUMN, поэтому: create → copy → drop → rename
+-- ------------------------------------------------------------
+
+CREATE TABLE categories_new (
+    id         TEXT    PRIMARY KEY,
+    user_id    INTEGER REFERENCES users(id) ON DELETE CASCADE, -- NULL для системных
+    name       TEXT    NOT NULL,
+    icon       TEXT    NOT NULL DEFAULT 'ellipsis.circle',
+    is_system  INTEGER NOT NULL DEFAULT 0,                     -- 1 = видна всем пользователям
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, name)
+);
+
+INSERT INTO categories_new (id, user_id, name, icon, is_system, created_at)
+SELECT                       id, user_id, name, icon, 0,         created_at
+FROM categories;
+
+DROP TABLE categories;
+ALTER TABLE categories_new RENAME TO categories;
+
+CREATE INDEX IF NOT EXISTS idx_categories_user_id ON categories(user_id);

--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -1,0 +1,281 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/models"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/repository"
+	"github.com/go-chi/chi/v5"
+)
+
+type AdminHandler struct {
+	admin *repository.AdminRepository
+	users *repository.UserRepository
+}
+
+func NewAdminHandler(admin *repository.AdminRepository, users *repository.UserRepository) *AdminHandler {
+	return &AdminHandler{admin: admin, users: users}
+}
+
+// ============================================================
+// Статистика
+// ============================================================
+
+// Stats godoc
+// GET /admin/stats
+func (h *AdminHandler) Stats(w http.ResponseWriter, r *http.Request) {
+	stats, err := h.admin.GetStats()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения статистики")
+		return
+	}
+	respondJSON(w, http.StatusOK, stats)
+}
+
+// ============================================================
+// Пользователи
+// ============================================================
+
+// ListUsers godoc
+// GET /admin/users?limit=20&offset=0&role=admin&search=john
+func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	limit, offset := parsePagination(r)
+	role := r.URL.Query().Get("role")
+	search := strings.TrimSpace(r.URL.Query().Get("search"))
+
+	page, err := h.admin.ListUsers(limit, offset, role, search)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения пользователей")
+		return
+	}
+	respondJSON(w, http.StatusOK, page)
+}
+
+// GetUser godoc
+// GET /admin/users/{id}
+func (h *AdminHandler) GetUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUserID(w, r)
+	if !ok {
+		return
+	}
+
+	user, err := h.admin.GetUser(id)
+	if errors.Is(err, repository.ErrNotFound) {
+		respondError(w, http.StatusNotFound, "пользователь не найден")
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения пользователя")
+		return
+	}
+	respondJSON(w, http.StatusOK, user)
+}
+
+// UpdateUser godoc
+// PATCH /admin/users/{id}
+// Поддерживает: role, is_blocked, blocked_reason, display_name.
+// Каждое поле опциональное — меняем только то что пришло.
+type updateUserRequest struct {
+	Role          *string `json:"role"`
+	IsBlocked     *bool   `json:"is_blocked"`
+	BlockedReason *string `json:"blocked_reason"`
+	DisplayName   *string `json:"display_name"`
+}
+
+func (h *AdminHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUserID(w, r)
+	if !ok {
+		return
+	}
+
+	var req updateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "невалидный JSON")
+		return
+	}
+
+	// Применяем только те поля которые пришли в запросе
+	if req.Role != nil {
+		role := models.UserRole(*req.Role)
+		if role != models.UserRoleUser && role != models.UserRoleAdmin {
+			respondError(w, http.StatusBadRequest, "допустимые роли: user, admin")
+			return
+		}
+		if err := h.users.SetRole(id, role); err != nil {
+			respondError(w, http.StatusInternalServerError, "ошибка обновления роли")
+			return
+		}
+	}
+
+	if req.IsBlocked != nil {
+		reason := ""
+		if req.BlockedReason != nil {
+			reason = strings.TrimSpace(*req.BlockedReason)
+		}
+		if err := h.users.SetBlocked(id, *req.IsBlocked, reason); err != nil {
+			respondError(w, http.StatusInternalServerError, "ошибка обновления статуса блокировки")
+			return
+		}
+	}
+
+	if req.DisplayName != nil {
+		name := strings.TrimSpace(*req.DisplayName)
+		if name == "" {
+			respondError(w, http.StatusBadRequest, "display_name не может быть пустым")
+			return
+		}
+		if err := h.users.UpdateDisplayName(id, name); err != nil {
+			respondError(w, http.StatusInternalServerError, "ошибка обновления имени")
+			return
+		}
+	}
+
+	// Возвращаем актуальное состояние пользователя
+	user, err := h.admin.GetUser(id)
+	if errors.Is(err, repository.ErrNotFound) {
+		respondError(w, http.StatusNotFound, "пользователь не найден")
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения пользователя")
+		return
+	}
+	respondJSON(w, http.StatusOK, user)
+}
+
+// DeleteUser godoc
+// DELETE /admin/users/{id}
+func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUserID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.users.Delete(id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respondError(w, http.StatusNotFound, "пользователь не найден")
+			return
+		}
+		respondError(w, http.StatusInternalServerError, "ошибка удаления пользователя")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ============================================================
+// Системные категории
+// ============================================================
+
+// ListSystemCategories godoc
+// GET /admin/categories
+func (h *AdminHandler) ListSystemCategories(w http.ResponseWriter, r *http.Request) {
+	cats, err := h.admin.ListSystemCategories()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения категорий")
+		return
+	}
+	respondJSON(w, http.StatusOK, cats)
+}
+
+// CreateSystemCategory godoc
+// POST /admin/categories
+type createCategoryRequest struct {
+	Name string `json:"name"`
+	Icon string `json:"icon"`
+}
+
+func (h *AdminHandler) CreateSystemCategory(w http.ResponseWriter, r *http.Request) {
+	var req createCategoryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "невалидный JSON")
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	req.Icon = strings.TrimSpace(req.Icon)
+
+	if req.Name == "" {
+		respondError(w, http.StatusBadRequest, "name обязателен")
+		return
+	}
+	if req.Icon == "" {
+		req.Icon = "ellipsis.circle" // дефолтная иконка
+	}
+
+	cat, err := h.admin.CreateSystemCategory(req.Name, req.Icon)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE") {
+			respondError(w, http.StatusConflict, "категория с таким именем уже существует")
+			return
+		}
+		respondError(w, http.StatusInternalServerError, "ошибка создания категории")
+		return
+	}
+
+	respondJSON(w, http.StatusCreated, cat)
+}
+
+// DeleteSystemCategory godoc
+// DELETE /admin/categories/{id}
+func (h *AdminHandler) DeleteSystemCategory(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		respondError(w, http.StatusBadRequest, "id обязателен")
+		return
+	}
+
+	if err := h.admin.DeleteSystemCategory(id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respondError(w, http.StatusNotFound, "категория не найдена")
+			return
+		}
+		respondError(w, http.StatusInternalServerError, "ошибка удаления категории")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ============================================================
+// Вспомогательные функции
+// ============================================================
+
+// parsePagination читает limit/offset из query параметров.
+// Дефолты: limit=20, offset=0. Максимум limit=100.
+func parsePagination(r *http.Request) (limit, offset int) {
+	limit = 20
+	offset = 0
+
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+
+	return limit, offset
+}
+
+// parseUserID читает и валидирует {id} из URL.
+func parseUserID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		respondError(w, http.StatusBadRequest, "некорректный id пользователя")
+		return 0, false
+	}
+	return id, true
+}

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -145,10 +145,15 @@ func (h *AuthHandler) SelfHosted(w http.ResponseWriter, r *http.Request) {
 	const selfHostedEmail = "admin@self-hosted.local"
 	user, err := h.users.FindByEmail(selfHostedEmail)
 	if errors.Is(err, repository.ErrNotFound) {
-		// Первый вход — создаём пользователя
+		// Первый вход — создаём пользователя и форсируем роль admin,
+		// не полагаясь на CountAll (в БД могут быть другие пользователи)
 		id, err := h.users.Create(selfHostedEmail, "", models.AuthProviderLocal, "self-hosted")
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "ошибка создания пользователя")
+			return
+		}
+		if err := h.users.SetRole(id, models.UserRoleAdmin); err != nil {
+			respondError(w, http.StatusInternalServerError, "ошибка назначения роли")
 			return
 		}
 		token, err := auth.GenerateToken(id, h.config.JWTSecret)

--- a/backend/internal/handlers/me.go
+++ b/backend/internal/handlers/me.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/auth"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/config"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/repository"
+)
+
+type MeHandler struct {
+	users  *repository.UserRepository
+	config *config.Config
+}
+
+func NewMeHandler(users *repository.UserRepository, cfg *config.Config) *MeHandler {
+	return &MeHandler{users: users, config: cfg}
+}
+
+// Me godoc
+// GET /auth/me
+// Возвращает публичный профиль текущего пользователя.
+func (h *MeHandler) Me(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	user, err := h.users.FindByID(userID)
+	if errors.Is(err, repository.ErrNotFound) {
+		respondError(w, http.StatusNotFound, "пользователь не найден")
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения профиля")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, user.ToPublic())
+}
+
+// UpdateMe godoc
+// PATCH /auth/me
+// Обновляет display_name текущего пользователя.
+type updateMeRequest struct {
+	DisplayName string `json:"display_name"`
+}
+
+func (h *MeHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var req updateMeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "невалидный JSON")
+		return
+	}
+
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	if req.DisplayName == "" {
+		respondError(w, http.StatusBadRequest, "display_name не может быть пустым")
+		return
+	}
+
+	if err := h.users.UpdateDisplayName(userID, req.DisplayName); err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка обновления профиля")
+		return
+	}
+
+	user, err := h.users.FindByID(userID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения профиля")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, user.ToPublic())
+}
+
+// ChangePassword godoc
+// POST /auth/me/change-password
+// Меняет пароль текущего пользователя. Требует старый пароль для подтверждения.
+type changePasswordRequest struct {
+	OldPassword string `json:"old_password"`
+	NewPassword string `json:"new_password"`
+}
+
+func (h *MeHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var req changePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "невалидный JSON")
+		return
+	}
+
+	user, err := h.users.FindByID(userID)
+	if errors.Is(err, repository.ErrNotFound) {
+		respondError(w, http.StatusNotFound, "пользователь не найден")
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка получения профиля")
+		return
+	}
+
+	// Self-hosted пользователь входит по server_secret, у него нет пароля
+	if user.PasswordHash == "" {
+		respondError(w, http.StatusBadRequest, "смена пароля недоступна для self-hosted аккаунта")
+		return
+	}
+
+	if !auth.CheckPassword(req.OldPassword, user.PasswordHash) {
+		respondError(w, http.StatusUnauthorized, "неверный текущий пароль")
+		return
+	}
+
+	newHash, err := auth.HashPassword(req.NewPassword)
+	if errors.Is(err, auth.ErrWeakPassword) {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка хэширования пароля")
+		return
+	}
+
+	if err := h.users.UpdatePassword(userID, newHash); err != nil {
+		respondError(w, http.StatusInternalServerError, "ошибка смены пароля")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -11,12 +11,85 @@ const (
 	AuthProviderApple  AuthProvider = "apple"
 )
 
+// UserRole — роль пользователя в системе
+type UserRole string
+
+const (
+	UserRoleUser  UserRole = "user"
+	UserRoleAdmin UserRole = "admin"
+)
+
 // User — пользователь системы
 type User struct {
-	ID           int64        `json:"id"`
-	Email        string       `json:"email"`
-	PasswordHash string       `json:"-"` // никогда не отдаём клиенту
-	Provider     AuthProvider `json:"provider"`
-	ProviderID   string       `json:"-"` // ID пользователя у провайдера (Google sub, Apple sub)
-	CreatedAt    time.Time    `json:"created_at"`
+	ID            int64        `json:"id"`
+	Email         string       `json:"email"`
+	PasswordHash  string       `json:"-"` // никогда не отдаём клиенту
+	Provider      AuthProvider `json:"provider"`
+	ProviderID    string       `json:"-"` // ID пользователя у провайдера (Google sub, Apple sub)
+	Role          UserRole     `json:"role"`
+	IsBlocked     bool         `json:"is_blocked"`
+	BlockedAt     *time.Time   `json:"blocked_at,omitempty"`
+	BlockedReason *string      `json:"blocked_reason,omitempty"`
+	DisplayName   string       `json:"display_name"`
+	LastSeenAt    *time.Time   `json:"last_seen_at,omitempty"`
+	CreatedAt     time.Time    `json:"created_at"`
+}
+
+// IsAdmin возвращает true если пользователь — администратор.
+func (u *User) IsAdmin() bool {
+	return u.Role == UserRoleAdmin
+}
+
+// UserPublic — безопасное представление пользователя для API-ответов.
+// Используется в /auth/me и в списках пользователей для не-админов.
+type UserPublic struct {
+	ID          int64        `json:"id"`
+	Email       string       `json:"email"`
+	DisplayName string       `json:"display_name"`
+	Provider    AuthProvider `json:"provider"`
+	Role        UserRole     `json:"role"`
+	CreatedAt   time.Time    `json:"created_at"`
+}
+
+// UserAdmin — расширенное представление для /admin/users/*.
+// Включает поля блокировки и активности.
+type UserAdmin struct {
+	ID            int64        `json:"id"`
+	Email         string       `json:"email"`
+	DisplayName   string       `json:"display_name"`
+	Provider      AuthProvider `json:"provider"`
+	Role          UserRole     `json:"role"`
+	IsBlocked     bool         `json:"is_blocked"`
+	BlockedAt     *time.Time   `json:"blocked_at,omitempty"`
+	BlockedReason *string      `json:"blocked_reason,omitempty"`
+	LastSeenAt    *time.Time   `json:"last_seen_at,omitempty"`
+	CreatedAt     time.Time    `json:"created_at"`
+}
+
+// ToPublic конвертирует User в UserPublic.
+func (u *User) ToPublic() UserPublic {
+	return UserPublic{
+		ID:          u.ID,
+		Email:       u.Email,
+		DisplayName: u.DisplayName,
+		Provider:    u.Provider,
+		Role:        u.Role,
+		CreatedAt:   u.CreatedAt,
+	}
+}
+
+// ToAdmin конвертирует User в UserAdmin.
+func (u *User) ToAdmin() UserAdmin {
+	return UserAdmin{
+		ID:            u.ID,
+		Email:         u.Email,
+		DisplayName:   u.DisplayName,
+		Provider:      u.Provider,
+		Role:          u.Role,
+		IsBlocked:     u.IsBlocked,
+		BlockedAt:     u.BlockedAt,
+		BlockedReason: u.BlockedReason,
+		LastSeenAt:    u.LastSeenAt,
+		CreatedAt:     u.CreatedAt,
+	}
 }

--- a/backend/internal/models/user_content.go
+++ b/backend/internal/models/user_content.go
@@ -1,11 +1,12 @@
 package models
 
-// Category — пользовательская категория подписки
+// Category — категория подписки (пользовательская или системная)
 type Category struct {
-	ID        string         `json:"id"` // UUID
-	UserID    int64          `json:"user_id"`
+	ID        string         `json:"id"`      // UUID
+	UserID    *int64         `json:"user_id"` // nil для системных категорий
 	Name      string         `json:"name"`
-	Icon      string         `json:"icon"` // SF Symbol name
+	Icon      string         `json:"icon"`      // SF Symbol name
+	IsSystem  bool           `json:"is_system"` // true — видна всем пользователям
 	CreatedAt RFC3339Seconds `json:"created_at"`
 }
 

--- a/backend/internal/repository/admin_repo.go
+++ b/backend/internal/repository/admin_repo.go
@@ -1,0 +1,250 @@
+package repository
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/models"
+	"github.com/google/uuid"
+)
+
+type AdminRepository struct {
+	db *sql.DB
+}
+
+func NewAdminRepository(db *sql.DB) *AdminRepository {
+	return &AdminRepository{db: db}
+}
+
+// ============================================================
+// Пользователи
+// ============================================================
+
+// UsersPage — результат постраничного запроса пользователей.
+type UsersPage struct {
+	Users  []models.UserAdmin `json:"users"`
+	Total  int64              `json:"total"`
+	Limit  int                `json:"limit"`
+	Offset int                `json:"offset"`
+}
+
+// ListUsers возвращает постраничный список всех пользователей.
+// Поддерживает фильтрацию по роли и статусу блокировки.
+func (r *AdminRepository) ListUsers(limit, offset int, role, search string) (UsersPage, error) {
+	// Собираем WHERE условия динамически
+	where := "WHERE 1=1"
+	args := []any{}
+
+	if role != "" {
+		where += " AND role = ?"
+		args = append(args, role)
+	}
+	if search != "" {
+		where += " AND (email LIKE ? OR display_name LIKE ?)"
+		pattern := "%" + search + "%"
+		args = append(args, pattern, pattern)
+	}
+
+	// Общее количество для пагинации
+	var total int64
+	countArgs := make([]any, len(args))
+	copy(countArgs, args)
+	if err := r.db.QueryRow("SELECT COUNT(*) FROM users "+where, countArgs...).Scan(&total); err != nil {
+		return UsersPage{}, err
+	}
+
+	// Сам список
+	args = append(args, limit, offset)
+	rows, err := r.db.Query(
+		`SELECT id, email, display_name, provider, role,
+		        is_blocked, blocked_at, blocked_reason,
+		        last_seen_at, created_at
+		 FROM users `+where+`
+		 ORDER BY created_at DESC
+		 LIMIT ? OFFSET ?`,
+		args...,
+	)
+	if err != nil {
+		return UsersPage{}, err
+	}
+	defer rows.Close()
+
+	users := []models.UserAdmin{}
+	for rows.Next() {
+		u, err := scanUserAdmin(rows)
+		if err != nil {
+			return UsersPage{}, err
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return UsersPage{}, err
+	}
+
+	return UsersPage{
+		Users:  users,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+// GetUser возвращает одного пользователя для админки.
+func (r *AdminRepository) GetUser(id int64) (models.UserAdmin, error) {
+	row := r.db.QueryRow(
+		`SELECT id, email, display_name, provider, role,
+		        is_blocked, blocked_at, blocked_reason,
+		        last_seen_at, created_at
+		 FROM users WHERE id = ?`, id,
+	)
+	var u models.UserAdmin
+	var isBlocked int
+	err := row.Scan(
+		&u.ID, &u.Email, &u.DisplayName, &u.Provider, &u.Role,
+		&isBlocked, &u.BlockedAt, &u.BlockedReason,
+		&u.LastSeenAt, &u.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return u, ErrNotFound
+	}
+	if err != nil {
+		return u, err
+	}
+	u.IsBlocked = isBlocked == 1
+	return u, nil
+}
+
+// ============================================================
+// Статистика
+// ============================================================
+
+// Stats — общая статистика системы для дашборда админки.
+type Stats struct {
+	TotalUsers         int64 `json:"total_users"`
+	TotalAdmins        int64 `json:"total_admins"`
+	TotalBlocked       int64 `json:"total_blocked"`
+	TotalSubscriptions int64 `json:"total_subscriptions"`
+	TotalCategories    int64 `json:"total_categories"`
+	TotalTags          int64 `json:"total_tags"`
+	NewUsersLast30Days int64 `json:"new_users_last_30_days"`
+}
+
+// GetStats возвращает агрегированную статистику по всей системе.
+func (r *AdminRepository) GetStats() (Stats, error) {
+	var s Stats
+
+	queries := []struct {
+		dest  *int64
+		query string
+		args  []any
+	}{
+		{&s.TotalUsers, `SELECT COUNT(*) FROM users`, nil},
+		{&s.TotalAdmins, `SELECT COUNT(*) FROM users WHERE role = 'admin'`, nil},
+		{&s.TotalBlocked, `SELECT COUNT(*) FROM users WHERE is_blocked = 1`, nil},
+		{&s.TotalSubscriptions, `SELECT COUNT(*) FROM subscriptions`, nil},
+		{&s.TotalCategories, `SELECT COUNT(*) FROM categories WHERE is_system = 0`, nil},
+		{&s.TotalTags, `SELECT COUNT(*) FROM tags`, nil},
+		{&s.NewUsersLast30Days, `SELECT COUNT(*) FROM users WHERE created_at >= ?`,
+			[]any{time.Now().AddDate(0, 0, -30)}},
+	}
+
+	for _, q := range queries {
+		if err := r.db.QueryRow(q.query, q.args...).Scan(q.dest); err != nil {
+			return s, err
+		}
+	}
+
+	return s, nil
+}
+
+// ============================================================
+// Системные категории
+// ============================================================
+
+// ListSystemCategories возвращает все системные категории.
+func (r *AdminRepository) ListSystemCategories() ([]models.Category, error) {
+	rows, err := r.db.Query(
+		`SELECT id, user_id, name, icon, is_system, created_at
+		 FROM categories WHERE is_system = 1 ORDER BY name`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cats := []models.Category{}
+	for rows.Next() {
+		c, err := scanCategory(rows)
+		if err != nil {
+			return nil, err
+		}
+		cats = append(cats, c)
+	}
+	return cats, rows.Err()
+}
+
+// CreateSystemCategory создаёт глобальную категорию видимую всем пользователям.
+func (r *AdminRepository) CreateSystemCategory(name, icon string) (models.Category, error) {
+	now := time.Now()
+	c := models.Category{
+		ID:        uuid.NewString(),
+		UserID:    nil, // системная — не принадлежит никому
+		Name:      name,
+		Icon:      icon,
+		IsSystem:  true,
+		CreatedAt: models.RFC3339Seconds(now),
+	}
+	_, err := r.db.Exec(
+		`INSERT INTO categories (id, user_id, name, icon, is_system, created_at)
+		 VALUES (?, NULL, ?, ?, 1, ?)`,
+		c.ID, c.Name, c.Icon, now,
+	)
+	return c, err
+}
+
+// DeleteSystemCategory удаляет системную категорию.
+// Обычные пользовательские категории через этот метод удалить нельзя.
+func (r *AdminRepository) DeleteSystemCategory(id string) error {
+	result, err := r.db.Exec(
+		`DELETE FROM categories WHERE id = ? AND is_system = 1`, id,
+	)
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ============================================================
+// Вспомогательные функции сканирования
+// ============================================================
+
+func scanUserAdmin(rows *sql.Rows) (models.UserAdmin, error) {
+	var u models.UserAdmin
+	var isBlocked int
+	err := rows.Scan(
+		&u.ID, &u.Email, &u.DisplayName, &u.Provider, &u.Role,
+		&isBlocked, &u.BlockedAt, &u.BlockedReason,
+		&u.LastSeenAt, &u.CreatedAt,
+	)
+	if err != nil {
+		return u, err
+	}
+	u.IsBlocked = isBlocked == 1
+	return u, nil
+}
+
+func scanCategory(rows *sql.Rows) (models.Category, error) {
+	var c models.Category
+	var createdAt time.Time
+	var isSystem int
+	err := rows.Scan(&c.ID, &c.UserID, &c.Name, &c.Icon, &isSystem, &createdAt)
+	if err != nil {
+		return c, err
+	}
+	c.IsSystem = isSystem == 1
+	c.CreatedAt = models.RFC3339Seconds(createdAt)
+	return c, nil
+}

--- a/backend/internal/repository/category_repo.go
+++ b/backend/internal/repository/category_repo.go
@@ -17,65 +17,98 @@ func NewCategoryRepository(db *sql.DB) *CategoryRepository {
 	return &CategoryRepository{db: db}
 }
 
-// FindAllByUser возвращает все пользовательские категории.
+// FindAllByUser возвращает системные категории + личные категории пользователя.
+// Системные идут первыми, затем пользовательские по алфавиту.
 func (r *CategoryRepository) FindAllByUser(userID int64) ([]models.Category, error) {
 	rows, err := r.db.Query(
-		`SELECT id, user_id, name, icon, created_at
-		 FROM categories WHERE user_id = ? ORDER BY name`, userID,
+		`SELECT id, user_id, name, icon, is_system, created_at
+		 FROM categories
+		 WHERE is_system = 1 OR user_id = ?
+		 ORDER BY is_system DESC, name ASC`, userID,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var cats []models.Category
+	cats := []models.Category{}
 	for rows.Next() {
-		var c models.Category
-		var createdAt time.Time
-		if err := rows.Scan(&c.ID, &c.UserID, &c.Name, &c.Icon, &createdAt); err != nil {
+		c, err := scanCategoryRow(rows)
+		if err != nil {
 			return nil, err
 		}
-		c.CreatedAt = models.RFC3339Seconds(createdAt)
 		cats = append(cats, c)
 	}
 	return cats, rows.Err()
 }
 
-// FindOrCreate возвращает категорию по имени или создаёт новую (идемпотентно).
+// FindOrCreate возвращает пользовательскую категорию по имени или создаёт новую (идемпотентно).
+// Системные категории через этот метод не создаются — для них AdminRepository.
 func (r *CategoryRepository) FindOrCreate(userID int64, name, icon string) (models.Category, error) {
 	var c models.Category
 	var createdAt time.Time
+	var isSystem int
+
 	err := r.db.QueryRow(
-		`SELECT id, user_id, name, icon, created_at FROM categories WHERE user_id = ? AND name = ?`,
+		`SELECT id, user_id, name, icon, is_system, created_at
+		 FROM categories WHERE user_id = ? AND name = ?`,
 		userID, name,
-	).Scan(&c.ID, &c.UserID, &c.Name, &c.Icon, &createdAt)
+	).Scan(&c.ID, &c.UserID, &c.Name, &c.Icon, &isSystem, &createdAt)
 
 	if err == nil {
+		c.IsSystem = isSystem == 1
 		c.CreatedAt = models.RFC3339Seconds(createdAt)
-		return c, nil // нашли
+		return c, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return c, err
 	}
 
-	// Создаём новую
+	// Не нашли — создаём
 	now := time.Now()
+	userIDVal := int64(userID)
 	c = models.Category{
 		ID:        uuid.NewString(),
-		UserID:    userID,
+		UserID:    &userIDVal,
 		Name:      name,
 		Icon:      icon,
+		IsSystem:  false,
 		CreatedAt: models.RFC3339Seconds(now),
 	}
 	_, err = r.db.Exec(
-		`INSERT INTO categories (id, user_id, name, icon, created_at) VALUES (?, ?, ?, ?, ?)`,
-		c.ID, c.UserID, c.Name, c.Icon, now,
+		`INSERT INTO categories (id, user_id, name, icon, is_system, created_at)
+		 VALUES (?, ?, ?, ?, 0, ?)`,
+		c.ID, userID, c.Name, c.Icon, now,
 	)
 	return c, err
 }
 
-// Delete удаляет категорию пользователя.
+// Delete удаляет пользовательскую категорию.
+// Системные категории через этот метод удалить нельзя (is_system = 0).
 func (r *CategoryRepository) Delete(id string, userID int64) error {
-	_, err := r.db.Exec(`DELETE FROM categories WHERE id = ? AND user_id = ?`, id, userID)
-	return err
+	result, err := r.db.Exec(
+		`DELETE FROM categories WHERE id = ? AND user_id = ? AND is_system = 0`,
+		id, userID,
+	)
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// scanCategoryRow сканирует строку из *sql.Rows в models.Category.
+func scanCategoryRow(rows *sql.Rows) (models.Category, error) {
+	var c models.Category
+	var createdAt time.Time
+	var isSystem int
+	err := rows.Scan(&c.ID, &c.UserID, &c.Name, &c.Icon, &isSystem, &createdAt)
+	if err != nil {
+		return c, err
+	}
+	c.IsSystem = isSystem == 1
+	c.CreatedAt = models.RFC3339Seconds(createdAt)
+	return c, nil
 }

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -19,11 +19,21 @@ func NewUserRepository(db *sql.DB) *UserRepository {
 }
 
 // Create создаёт нового пользователя и возвращает его ID.
+// Если в таблице ещё нет ни одного пользователя — назначает роль admin.
 func (r *UserRepository) Create(email, passwordHash string, provider models.AuthProvider, providerID string) (int64, error) {
+	role := models.UserRoleUser
+	count, err := r.CountAll()
+	if err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		role = models.UserRoleAdmin
+	}
+
 	res, err := r.db.Exec(
-		`INSERT INTO users (email, password_hash, provider, provider_id, created_at)
-		 VALUES (?, ?, ?, ?, ?)`,
-		email, passwordHash, provider, providerID, time.Now(),
+		`INSERT INTO users (email, password_hash, provider, provider_id, role, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		email, passwordHash, provider, providerID, role, time.Now(),
 	)
 	if err != nil {
 		return 0, err
@@ -31,10 +41,19 @@ func (r *UserRepository) Create(email, passwordHash string, provider models.Auth
 	return res.LastInsertId()
 }
 
+// CountAll возвращает общее количество пользователей в системе.
+func (r *UserRepository) CountAll() (int64, error) {
+	var count int64
+	err := r.db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count)
+	return count, err
+}
+
 // FindByEmail ищет пользователя по email.
 func (r *UserRepository) FindByEmail(email string) (*models.User, error) {
 	row := r.db.QueryRow(
-		`SELECT id, email, password_hash, provider, provider_id, created_at
+		`SELECT id, email, password_hash, provider, provider_id,
+		        role, is_blocked, blocked_at, blocked_reason,
+		        display_name, last_seen_at, created_at
 		 FROM users WHERE email = ?`, email,
 	)
 	return scanUser(row)
@@ -43,7 +62,9 @@ func (r *UserRepository) FindByEmail(email string) (*models.User, error) {
 // FindByProviderID ищет пользователя по провайдеру и его ID (для OAuth).
 func (r *UserRepository) FindByProviderID(provider models.AuthProvider, providerID string) (*models.User, error) {
 	row := r.db.QueryRow(
-		`SELECT id, email, password_hash, provider, provider_id, created_at
+		`SELECT id, email, password_hash, provider, provider_id,
+		        role, is_blocked, blocked_at, blocked_reason,
+		        display_name, last_seen_at, created_at
 		 FROM users WHERE provider = ? AND provider_id = ?`, provider, providerID,
 	)
 	return scanUser(row)
@@ -52,20 +73,95 @@ func (r *UserRepository) FindByProviderID(provider models.AuthProvider, provider
 // FindByID ищет пользователя по ID.
 func (r *UserRepository) FindByID(id int64) (*models.User, error) {
 	row := r.db.QueryRow(
-		`SELECT id, email, password_hash, provider, provider_id, created_at
+		`SELECT id, email, password_hash, provider, provider_id,
+		        role, is_blocked, blocked_at, blocked_reason,
+		        display_name, last_seen_at, created_at
 		 FROM users WHERE id = ?`, id,
 	)
 	return scanUser(row)
 }
 
+// UpdateLastSeen обновляет время последней активности пользователя.
+func (r *UserRepository) UpdateLastSeen(id int64) error {
+	_, err := r.db.Exec(
+		`UPDATE users SET last_seen_at = ? WHERE id = ?`,
+		time.Now(), id,
+	)
+	return err
+}
+
+// UpdateDisplayName обновляет отображаемое имя пользователя.
+func (r *UserRepository) UpdateDisplayName(id int64, displayName string) error {
+	_, err := r.db.Exec(
+		`UPDATE users SET display_name = ? WHERE id = ?`,
+		displayName, id,
+	)
+	return err
+}
+
+// UpdatePassword обновляет хэш пароля пользователя.
+func (r *UserRepository) UpdatePassword(id int64, passwordHash string) error {
+	_, err := r.db.Exec(
+		`UPDATE users SET password_hash = ? WHERE id = ?`,
+		passwordHash, id,
+	)
+	return err
+}
+
+// SetRole назначает роль пользователю.
+func (r *UserRepository) SetRole(id int64, role models.UserRole) error {
+	_, err := r.db.Exec(
+		`UPDATE users SET role = ? WHERE id = ?`,
+		role, id,
+	)
+	return err
+}
+
+// SetBlocked блокирует или разблокирует пользователя.
+func (r *UserRepository) SetBlocked(id int64, blocked bool, reason string) error {
+	if blocked {
+		now := time.Now()
+		_, err := r.db.Exec(
+			`UPDATE users SET is_blocked = 1, blocked_at = ?, blocked_reason = ? WHERE id = ?`,
+			now, reason, id,
+		)
+		return err
+	}
+	_, err := r.db.Exec(
+		`UPDATE users SET is_blocked = 0, blocked_at = NULL, blocked_reason = NULL WHERE id = ?`,
+		id,
+	)
+	return err
+}
+
+// Delete удаляет пользователя и все его данные (CASCADE в БД).
+func (r *UserRepository) Delete(id int64) error {
+	result, err := r.db.Exec(`DELETE FROM users WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// scanUser сканирует строку БД в модель User.
+// Используется во всех Find* методах — единая точка маппинга.
 func scanUser(row *sql.Row) (*models.User, error) {
 	u := &models.User{}
-	err := row.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Provider, &u.ProviderID, &u.CreatedAt)
+	var isBlocked int // SQLite хранит bool как INTEGER
+	err := row.Scan(
+		&u.ID, &u.Email, &u.PasswordHash, &u.Provider, &u.ProviderID,
+		&u.Role, &isBlocked, &u.BlockedAt, &u.BlockedReason,
+		&u.DisplayName, &u.LastSeenAt, &u.CreatedAt,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, err
 	}
+	u.IsBlocked = isBlocked == 1
 	return u, nil
 }

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -1,9 +1,9 @@
 package server
 
 import (
-	"net/http"
-
 	"database/sql"
+	"net/http"
+	"strings"
 
 	"github.com/OctopyApps/SubRadar-BackEnd/internal/auth"
 	"github.com/OctopyApps/SubRadar-BackEnd/internal/config"
@@ -16,10 +16,11 @@ import (
 func NewRouter(db *sql.DB, cfg *config.Config) http.Handler {
 	r := chi.NewRouter()
 
-	// Middleware
+	// --- Глобальные middleware ---
+	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
-	r.Use(middleware.RealIP)
+	r.Use(corsMiddleware(cfg))
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -27,30 +28,43 @@ func NewRouter(db *sql.DB, cfg *config.Config) http.Handler {
 		})
 	})
 
-	// Репозитории
+	// --- Репозитории ---
 	userRepo := repository.NewUserRepository(db)
 	subRepo := repository.NewSubscriptionRepository(db)
 	tagRepo := repository.NewTagRepository(db)
 	categoryRepo := repository.NewCategoryRepository(db)
 	currencyRepo := repository.NewCurrencyRepository(db)
+	adminRepo := repository.NewAdminRepository(db)
 
-	// Хэндлеры
+	// --- Хендлеры ---
 	authHandler := handlers.NewAuthHandler(userRepo, cfg)
+	meHandler := handlers.NewMeHandler(userRepo, cfg)
 	subHandler := handlers.NewSubscriptionHandler(subRepo)
 	tagHandler := handlers.NewTagHandler(tagRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryRepo)
 	currencyHandler := handlers.NewCurrencyHandler(currencyRepo)
+	adminHandler := handlers.NewAdminHandler(adminRepo, userRepo)
 
-	// Публичные маршруты (без токена)
+	// --- Health check (публичный) ---
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// --- Публичные маршруты (без токена) ---
 	r.Post("/auth/register", authHandler.Register)
 	r.Post("/auth/login", authHandler.Login)
 	r.Post("/auth/self-hosted", authHandler.SelfHosted)
 	r.Post("/auth/google", authHandler.Google)
 	r.Post("/auth/apple", authHandler.Apple)
 
-	// Защищённые маршруты (нужен JWT)
+	// --- Защищённые маршруты (нужен JWT) ---
 	r.Group(func(r chi.Router) {
-		r.Use(auth.Middleware(cfg.JWTSecret))
+		r.Use(auth.Middleware(cfg.JWTSecret, userRepo))
+
+		// Профиль текущего пользователя
+		r.Get("/auth/me", meHandler.Me)
+		r.Patch("/auth/me", meHandler.UpdateMe)
+		r.Post("/auth/me/change-password", meHandler.ChangePassword)
 
 		// Подписки
 		r.Get("/subscriptions", subHandler.List)
@@ -63,21 +77,71 @@ func NewRouter(db *sql.DB, cfg *config.Config) http.Handler {
 		r.Post("/tags", tagHandler.Create)
 		r.Delete("/tags/{id}", tagHandler.Delete)
 
-		// Категории (только пользовательские)
+		// Категории — возвращает системные + пользовательские
 		r.Get("/categories", categoryHandler.List)
 		r.Post("/categories", categoryHandler.Create)
 		r.Delete("/categories/{id}", categoryHandler.Delete)
 
-		// Валюты (только пользовательские)
+		// Валюты
 		r.Get("/currencies", currencyHandler.List)
 		r.Post("/currencies", currencyHandler.Create)
 		r.Delete("/currencies/{id}", currencyHandler.Delete)
-	})
 
-	// Health check
-	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"status":"ok"}`))
+		// --- Admin-only маршруты ---
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+
+			r.Get("/admin/stats", adminHandler.Stats)
+
+			r.Get("/admin/users", adminHandler.ListUsers)
+			r.Get("/admin/users/{id}", adminHandler.GetUser)
+			r.Patch("/admin/users/{id}", adminHandler.UpdateUser)
+			r.Delete("/admin/users/{id}", adminHandler.DeleteUser)
+
+			r.Get("/admin/categories", adminHandler.ListSystemCategories)
+			r.Post("/admin/categories", adminHandler.CreateSystemCategory)
+			r.Delete("/admin/categories/{id}", adminHandler.DeleteSystemCategory)
+		})
 	})
 
 	return r
+}
+
+// corsMiddleware разрешает запросы из веб-клиентов.
+// В продакшене AllowedOrigins берётся из конфига, в dev разрешаем всё.
+func corsMiddleware(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			if origin != "" {
+				if cfg.CORSAllowAll || isAllowedOrigin(origin, cfg.CORSOrigins) {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+					w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+					w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
+					w.Header().Set("Access-Control-Max-Age", "86400")
+					w.Header().Set("Vary", "Origin")
+				}
+			}
+
+			// Preflight OPTIONS — отвечаем сразу без передачи дальше
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isAllowedOrigin проверяет входит ли origin в список разрешённых.
+func isAllowedOrigin(origin string, allowed []string) bool {
+	for _, a := range allowed {
+		if strings.EqualFold(a, origin) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/tests/integration/admin_test.go
+++ b/backend/tests/integration/admin_test.go
@@ -1,0 +1,320 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// itoa конвертирует int в строку — нужен для формирования URL с ID.
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}
+
+// getUserID достаёт ID текущего пользователя через /auth/me.
+func (a *testApp) getUserID(t *testing.T, token string) int {
+	t.Helper()
+	rec := a.do("GET", "/auth/me", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var me map[string]any
+	decodeJSON(t, rec, &me)
+	return int(me["id"].(float64))
+}
+
+// ── Stats ─────────────────────────────────────────────────────────────────────
+
+func TestAdminStats_AdminAccess(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/stats", nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var stats map[string]any
+	decodeJSON(t, rec, &stats)
+
+	fields := []string{
+		"total_users", "total_admins", "total_blocked",
+		"total_subscriptions", "total_categories", "total_tags",
+		"new_users_last_30_days",
+	}
+	for _, f := range fields {
+		assert.Contains(t, stats, f, "поле %s отсутствует в статистике", f)
+	}
+	assert.Equal(t, float64(2), stats["total_users"])
+	assert.Equal(t, float64(1), stats["total_admins"])
+}
+
+func TestAdminStats_UserForbidden(t *testing.T) {
+	a := newTestApp(t)
+	_, userToken := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/stats", nil, userToken)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestAdminStats_NoToken(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("GET", "/admin/stats", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ── List Users ────────────────────────────────────────────────────────────────
+
+func TestAdminListUsers_ReturnsAllUsers(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/users", nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	decodeJSON(t, rec, &page)
+
+	assert.Equal(t, float64(2), page["total"])
+	users := page["users"].([]any)
+	assert.Len(t, users, 2)
+
+	// Проверяем поля первого пользователя
+	u := users[0].(map[string]any)
+	for _, f := range []string{"id", "email", "display_name", "provider", "role", "is_blocked", "created_at"} {
+		assert.Contains(t, u, f, "поле %s отсутствует", f)
+	}
+}
+
+func TestAdminListUsers_FilterByRole(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/users?role=admin", nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	decodeJSON(t, rec, &page)
+	assert.Equal(t, float64(1), page["total"])
+}
+
+func TestAdminListUsers_Search(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/users?search=admin", nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	decodeJSON(t, rec, &page)
+	users := page["users"].([]any)
+	for _, u := range users {
+		email := u.(map[string]any)["email"].(string)
+		assert.Contains(t, email, "admin")
+	}
+}
+
+func TestAdminListUsers_Pagination(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/users?limit=1&offset=0", nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	decodeJSON(t, rec, &page)
+	assert.Equal(t, float64(2), page["total"]) // всего 2
+	assert.Equal(t, float64(1), page["limit"])
+	users := page["users"].([]any)
+	assert.Len(t, users, 1) // но вернули 1
+}
+
+// ── Get User ──────────────────────────────────────────────────────────────────
+
+func TestAdminGetUser_Found(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+	adminID := a.getUserID(t, adminToken)
+
+	rec := a.do("GET", fmt.Sprintf("/admin/users/%d", adminID), nil, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var u map[string]any
+	decodeJSON(t, rec, &u)
+	assert.Equal(t, float64(adminID), u["id"])
+	assert.Equal(t, "admin", u["role"])
+}
+
+func TestAdminGetUser_NotFound(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, _ := a.setupAdminAndUser(t)
+
+	rec := a.do("GET", "/admin/users/99999", nil, adminToken)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ── Update User ───────────────────────────────────────────────────────────────
+
+func TestAdminUpdateUser_BlockAndUnblock(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+	userID := a.getUserID(t, userToken)
+
+	// Блокируем
+	blockRec := a.do("PATCH", fmt.Sprintf("/admin/users/%d", userID), map[string]any{
+		"is_blocked":     true,
+		"blocked_reason": "тест блокировки",
+	}, adminToken)
+	require.Equal(t, http.StatusOK, blockRec.Code)
+
+	var blocked map[string]any
+	decodeJSON(t, blockRec, &blocked)
+	assert.True(t, blocked["is_blocked"].(bool))
+	assert.NotNil(t, blocked["blocked_at"])
+
+	// Убеждаемся что заблокированный не может войти
+	accessRec := a.do("GET", "/auth/me", nil, userToken)
+	assert.Equal(t, http.StatusForbidden, accessRec.Code)
+
+	// Разблокируем
+	unblockRec := a.do("PATCH", fmt.Sprintf("/admin/users/%d", userID), map[string]any{
+		"is_blocked": false,
+	}, adminToken)
+	require.Equal(t, http.StatusOK, unblockRec.Code)
+
+	var unblocked map[string]any
+	decodeJSON(t, unblockRec, &unblocked)
+	assert.False(t, unblocked["is_blocked"].(bool))
+
+	// После разблокировки токен снова работает
+	accessRec2 := a.do("GET", "/auth/me", nil, userToken)
+	assert.Equal(t, http.StatusOK, accessRec2.Code)
+}
+
+func TestAdminUpdateUser_ChangeRole(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+	userID := a.getUserID(t, userToken)
+
+	rec := a.do("PATCH", fmt.Sprintf("/admin/users/%d", userID), map[string]any{
+		"role": "admin",
+	}, adminToken)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var u map[string]any
+	decodeJSON(t, rec, &u)
+	assert.Equal(t, "admin", u["role"])
+
+	// Теперь этот пользователь тоже может ходить в admin endpoints
+	statsRec := a.do("GET", "/admin/stats", nil, userToken)
+	assert.Equal(t, http.StatusOK, statsRec.Code)
+}
+
+func TestAdminUpdateUser_InvalidRole(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+	userID := a.getUserID(t, userToken)
+
+	rec := a.do("PATCH", fmt.Sprintf("/admin/users/%d", userID), map[string]any{
+		"role": "superuser",
+	}, adminToken)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAdminUpdateUser_UserCannotUpdate(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+	adminID := a.getUserID(t, adminToken)
+
+	rec := a.do("PATCH", fmt.Sprintf("/admin/users/%d", adminID), map[string]any{
+		"role": "user",
+	}, userToken)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// ── Delete User ───────────────────────────────────────────────────────────────
+
+func TestAdminDeleteUser(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+	userID := a.getUserID(t, userToken)
+
+	rec := a.do("DELETE", fmt.Sprintf("/admin/users/%d", userID), nil, adminToken)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Удалённый пользователь больше не находится
+	getRec := a.do("GET", fmt.Sprintf("/admin/users/%d", userID), nil, adminToken)
+	assert.Equal(t, http.StatusNotFound, getRec.Code)
+
+	// Статистика обновилась
+	statsRec := a.do("GET", "/admin/stats", nil, adminToken)
+	var stats map[string]any
+	decodeJSON(t, statsRec, &stats)
+	assert.Equal(t, float64(1), stats["total_users"])
+}
+
+// ── System Categories ─────────────────────────────────────────────────────────
+
+func TestAdminSystemCategories_CreateAndList(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+
+	// Создаём системную категорию
+	createRec := a.do("POST", "/admin/categories", map[string]string{
+		"name": "Стриминг",
+		"icon": "play.circle",
+	}, adminToken)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	var cat map[string]any
+	decodeJSON(t, createRec, &cat)
+	assert.Equal(t, "Стриминг", cat["name"])
+	assert.True(t, cat["is_system"].(bool))
+	assert.Nil(t, cat["user_id"])
+
+	catID := cat["id"].(string)
+
+	// Список системных категорий
+	listRec := a.do("GET", "/admin/categories", nil, adminToken)
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var cats []any
+	decodeJSON(t, listRec, &cats)
+	assert.Len(t, cats, 1)
+
+	// Системная категория видна обычному пользователю
+	userCatsRec := a.do("GET", "/categories", nil, userToken)
+	require.Equal(t, http.StatusOK, userCatsRec.Code)
+
+	var userCats []any
+	decodeJSON(t, userCatsRec, &userCats)
+	found := false
+	for _, c := range userCats {
+		if c.(map[string]any)["id"] == catID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "системная категория должна быть видна обычному пользователю")
+
+	// Удаляем
+	deleteRec := a.do("DELETE", "/admin/categories/"+catID, nil, adminToken)
+	assert.Equal(t, http.StatusOK, deleteRec.Code)
+
+	// Список теперь пуст
+	listRec2 := a.do("GET", "/admin/categories", nil, adminToken)
+	var cats2 []any
+	decodeJSON(t, listRec2, &cats2)
+	assert.Empty(t, cats2)
+}
+
+func TestAdminSystemCategories_UserCannotCreate(t *testing.T) {
+	a := newTestApp(t)
+	_, userToken := a.setupAdminAndUser(t)
+
+	rec := a.do("POST", "/admin/categories", map[string]string{
+		"name": "Хакерская категория",
+		"icon": "exclamationmark.triangle",
+	}, userToken)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -1,0 +1,212 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealth(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("GET", "/health", nil, "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ── Register ──────────────────────────────────────────────────────────────────
+
+func TestRegister_FirstUserBecomesAdmin(t *testing.T) {
+	a := newTestApp(t)
+
+	rec := a.do("POST", "/auth/register", map[string]string{
+		"email":    "first@test.com",
+		"password": "password123",
+	}, "")
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp map[string]any
+	decodeJSON(t, rec, &resp)
+	require.NotEmpty(t, resp["token"])
+
+	// Проверяем что роль действительно admin
+	token := resp["token"].(string)
+	meRec := a.do("GET", "/auth/me", nil, token)
+	require.Equal(t, http.StatusOK, meRec.Code)
+
+	var me map[string]any
+	decodeJSON(t, meRec, &me)
+	assert.Equal(t, "admin", me["role"], "первый пользователь должен быть admin")
+}
+
+func TestRegister_SecondUserIsRegularUser(t *testing.T) {
+	a := newTestApp(t)
+	_ = a.registerUser(t, "first@test.com", "password123")
+
+	rec := a.do("POST", "/auth/register", map[string]string{
+		"email":    "second@test.com",
+		"password": "password123",
+	}, "")
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp map[string]any
+	decodeJSON(t, rec, &resp)
+	token := resp["token"].(string)
+
+	meRec := a.do("GET", "/auth/me", nil, token)
+	var me map[string]any
+	decodeJSON(t, meRec, &me)
+	assert.Equal(t, "user", me["role"], "второй пользователь должен быть user")
+}
+
+func TestRegister_DuplicateEmail(t *testing.T) {
+	a := newTestApp(t)
+	_ = a.registerUser(t, "dup@test.com", "password123")
+
+	rec := a.do("POST", "/auth/register", map[string]string{
+		"email":    "dup@test.com",
+		"password": "password123",
+	}, "")
+	assert.Equal(t, http.StatusConflict, rec.Code)
+
+	var resp map[string]any
+	decodeJSON(t, rec, &resp)
+	assert.Contains(t, resp, "error")
+}
+
+func TestRegister_WeakPassword(t *testing.T) {
+	a := newTestApp(t)
+
+	rec := a.do("POST", "/auth/register", map[string]string{
+		"email":    "weak@test.com",
+		"password": "123",
+	}, "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRegister_InvalidJSON(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("POST", "/auth/register", "не JSON", "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ── Login ─────────────────────────────────────────────────────────────────────
+
+func TestLogin_Success(t *testing.T) {
+	a := newTestApp(t)
+	_ = a.registerUser(t, "login@test.com", "password123")
+
+	rec := a.do("POST", "/auth/login", map[string]string{
+		"email":    "login@test.com",
+		"password": "password123",
+	}, "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	decodeJSON(t, rec, &resp)
+	assert.NotEmpty(t, resp["token"])
+}
+
+func TestLogin_WrongPassword(t *testing.T) {
+	a := newTestApp(t)
+	_ = a.registerUser(t, "login@test.com", "password123")
+
+	rec := a.do("POST", "/auth/login", map[string]string{
+		"email":    "login@test.com",
+		"password": "wrongpassword",
+	}, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestLogin_UnknownEmail(t *testing.T) {
+	a := newTestApp(t)
+
+	rec := a.do("POST", "/auth/login", map[string]string{
+		"email":    "ghost@test.com",
+		"password": "password123",
+	}, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ── Self-hosted ───────────────────────────────────────────────────────────────
+
+func TestSelfHosted_CorrectSecret(t *testing.T) {
+	a := newTestApp(t)
+	token := a.selfHostedLogin(t)
+	assert.NotEmpty(t, token)
+}
+
+func TestSelfHosted_AlwaysAdmin(t *testing.T) {
+	a := newTestApp(t)
+	// Сначала регистрируем обычного пользователя — self-hosted всё равно должен быть admin
+	_ = a.registerUser(t, "regular@test.com", "password123")
+
+	token := a.selfHostedLogin(t)
+
+	meRec := a.do("GET", "/auth/me", nil, token)
+	var me map[string]any
+	decodeJSON(t, meRec, &me)
+	assert.Equal(t, "admin", me["role"], "self-hosted пользователь всегда должен быть admin")
+}
+
+func TestSelfHosted_WrongSecret(t *testing.T) {
+	a := newTestApp(t)
+
+	rec := a.do("POST", "/auth/self-hosted", map[string]string{
+		"secret": "wrong_secret",
+	}, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestSelfHosted_SecondLoginReturnsSameUser(t *testing.T) {
+	a := newTestApp(t)
+
+	token1 := a.selfHostedLogin(t)
+	token2 := a.selfHostedLogin(t)
+
+	// Оба токена должны давать одного и того же пользователя
+	me1Rec := a.do("GET", "/auth/me", nil, token1)
+	me2Rec := a.do("GET", "/auth/me", nil, token2)
+
+	var me1, me2 map[string]any
+	decodeJSON(t, me1Rec, &me1)
+	decodeJSON(t, me2Rec, &me2)
+
+	assert.Equal(t, me1["id"], me2["id"], "повторный self-hosted вход должен давать того же пользователя")
+}
+
+// ── Auth middleware ───────────────────────────────────────────────────────────
+
+func TestProtectedRoute_NoToken(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("GET", "/auth/me", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestProtectedRoute_InvalidToken(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("GET", "/auth/me", nil, "not.a.valid.token")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestProtectedRoute_BlockedUser(t *testing.T) {
+	a := newTestApp(t)
+	adminToken, userToken := a.setupAdminAndUser(t)
+
+	// Получаем ID второго пользователя
+	meRec := a.do("GET", "/auth/me", nil, userToken)
+	var me map[string]any
+	decodeJSON(t, meRec, &me)
+	userID := int(me["id"].(float64))
+
+	// Блокируем
+	blockRec := a.do("PATCH", "/admin/users/"+itoa(userID), map[string]any{
+		"is_blocked":     true,
+		"blocked_reason": "тест",
+	}, adminToken)
+	require.Equal(t, http.StatusOK, blockRec.Code)
+
+	// Заблокированный не может обратиться к API
+	rec := a.do("GET", "/auth/me", nil, userToken)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/backend/tests/integration/mme_test.go
+++ b/backend/tests/integration/mme_test.go
@@ -1,0 +1,132 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMe_ReturnsProfile(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "me@test.com", "password123")
+
+	rec := a.do("GET", "/auth/me", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var me map[string]any
+	decodeJSON(t, rec, &me)
+
+	assert.Equal(t, "me@test.com", me["email"])
+	assert.Equal(t, "admin", me["role"]) // первый пользователь
+	assert.Equal(t, "local", me["provider"])
+	assert.NotContains(t, me, "password_hash", "хэш пароля не должен утекать")
+	assert.NotContains(t, me, "provider_id")
+
+	for _, f := range []string{"id", "email", "display_name", "provider", "role", "created_at"} {
+		assert.Contains(t, me, f)
+	}
+}
+
+func TestMe_NoToken(t *testing.T) {
+	a := newTestApp(t)
+	rec := a.do("GET", "/auth/me", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ── PATCH /auth/me ────────────────────────────────────────────────────────────
+
+func TestUpdateMe_DisplayName(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "update@test.com", "password123")
+
+	rec := a.do("PATCH", "/auth/me", map[string]string{
+		"display_name": "Алексей",
+	}, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var me map[string]any
+	decodeJSON(t, rec, &me)
+	assert.Equal(t, "Алексей", me["display_name"])
+
+	// Проверяем что изменение персистентно
+	meRec := a.do("GET", "/auth/me", nil, token)
+	var me2 map[string]any
+	decodeJSON(t, meRec, &me2)
+	assert.Equal(t, "Алексей", me2["display_name"])
+}
+
+func TestUpdateMe_EmptyDisplayName(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "update@test.com", "password123")
+
+	rec := a.do("PATCH", "/auth/me", map[string]string{
+		"display_name": "",
+	}, token)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdateMe_WhitespaceDisplayName(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "update@test.com", "password123")
+
+	rec := a.do("PATCH", "/auth/me", map[string]string{
+		"display_name": "   ",
+	}, token)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ── POST /auth/me/change-password ─────────────────────────────────────────────
+
+func TestChangePassword_Success(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "pw@test.com", "oldpassword")
+
+	rec := a.do("POST", "/auth/me/change-password", map[string]string{
+		"old_password": "oldpassword",
+		"new_password": "newpassword123",
+	}, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Старый пароль больше не работает
+	loginOldRec := a.do("POST", "/auth/login", map[string]string{
+		"email":    "pw@test.com",
+		"password": "oldpassword",
+	}, "")
+	assert.Equal(t, http.StatusUnauthorized, loginOldRec.Code)
+
+	// Новый пароль работает
+	loginNewRec := a.do("POST", "/auth/login", map[string]string{
+		"email":    "pw@test.com",
+		"password": "newpassword123",
+	}, "")
+	assert.Equal(t, http.StatusOK, loginNewRec.Code)
+}
+
+func TestChangePassword_WrongOldPassword(t *testing.T) {
+	a := newTestApp(t)
+	token := a.registerUser(t, "pw@test.com", "correctpassword")
+
+	rec := a.do("POST", "/auth/me/change-password", map[string]string{
+		"old_password": "wrongpassword",
+		"new_password": "newpassword123",
+	}, token)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestChangePassword_SelfHostedAccount(t *testing.T) {
+	a := newTestApp(t)
+	token := a.selfHostedLogin(t)
+
+	// Self-hosted аккаунт не имеет пароля — должна быть понятная ошибка
+	rec := a.do("POST", "/auth/me/change-password", map[string]string{
+		"old_password": "anything",
+		"new_password": "newpassword123",
+	}, token)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	decodeJSON(t, rec, &resp)
+	assert.Contains(t, resp, "error")
+}

--- a/backend/tests/integration/setup_test.go
+++ b/backend/tests/integration/setup_test.go
@@ -1,0 +1,136 @@
+package integration
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/config"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/db"
+	"github.com/OctopyApps/SubRadar-BackEnd/internal/server"
+	"github.com/stretchr/testify/require"
+)
+
+// testApp — собранное приложение для одного теста.
+type testApp struct {
+	router http.Handler
+	db     *sql.DB
+}
+
+// newTestApp поднимает SQLite в памяти, применяет миграции и возвращает роутер.
+// Каждый вызов даёт чистую изолированную БД — тесты не влияют друг на друга.
+func newTestApp(t *testing.T) *testApp {
+	t.Helper()
+
+	database, err := db.Connect("sqlite", ":memory:")
+	require.NoError(t, err, "не удалось создать тестовую БД")
+
+	t.Cleanup(func() { database.Close() })
+
+	cfg := testConfig()
+	router := server.NewRouter(database, cfg)
+
+	return &testApp{router: router, db: database}
+}
+
+// testConfig возвращает конфиг для тестового окружения.
+func testConfig() *config.Config {
+	return &config.Config{
+		Port:         8080,
+		DBDriver:     "sqlite",
+		DBPath:       ":memory:",
+		JWTSecret:    "test-jwt-secret",
+		SelfHosted:   true,
+		ServerSecret: "test-server-secret",
+		CORSAllowAll: true,
+	}
+}
+
+// ── HTTP хелперы ──────────────────────────────────────────────────────────────
+
+// do выполняет HTTP запрос к роутеру и возвращает recorder.
+func (a *testApp) do(method, path string, body any, token string) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	rec := httptest.NewRecorder()
+	a.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// decodeJSON декодирует тело ответа в переданную структуру.
+func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, dst any) {
+	t.Helper()
+	err := json.NewDecoder(rec.Body).Decode(dst)
+	require.NoError(t, err, "не удалось декодировать JSON ответ: %s", rec.Body.String())
+}
+
+// ── Auth хелперы ──────────────────────────────────────────────────────────────
+
+type authResponse struct {
+	Token string `json:"token"`
+}
+
+// registerUser регистрирует пользователя и возвращает JWT токен.
+func (a *testApp) registerUser(t *testing.T, email, password string) string {
+	t.Helper()
+	rec := a.do("POST", "/auth/register", map[string]string{
+		"email":    email,
+		"password": password,
+	}, "")
+	require.Equal(t, http.StatusCreated, rec.Code, "register failed: %s", rec.Body.String())
+
+	var resp authResponse
+	decodeJSON(t, rec, &resp)
+	require.NotEmpty(t, resp.Token, "токен не вернулся при регистрации")
+	return resp.Token
+}
+
+// loginUser выполняет вход и возвращает JWT токен.
+func (a *testApp) loginUser(t *testing.T, email, password string) string {
+	t.Helper()
+	rec := a.do("POST", "/auth/login", map[string]string{
+		"email":    email,
+		"password": password,
+	}, "")
+	require.Equal(t, http.StatusOK, rec.Code, "login failed: %s", rec.Body.String())
+
+	var resp authResponse
+	decodeJSON(t, rec, &resp)
+	require.NotEmpty(t, resp.Token)
+	return resp.Token
+}
+
+// selfHostedLogin выполняет self-hosted вход и возвращает токен.
+func (a *testApp) selfHostedLogin(t *testing.T) string {
+	t.Helper()
+	rec := a.do("POST", "/auth/self-hosted", map[string]string{
+		"secret": testConfig().ServerSecret,
+	}, "")
+	require.Equal(t, http.StatusOK, rec.Code, "self-hosted login failed: %s", rec.Body.String())
+
+	var resp authResponse
+	decodeJSON(t, rec, &resp)
+	require.NotEmpty(t, resp.Token)
+	return resp.Token
+}
+
+// setupAdminAndUser создаёт двух пользователей: первый admin, второй user.
+// Возвращает токены обоих — удобно для тестов разграничения прав.
+func (a *testApp) setupAdminAndUser(t *testing.T) (adminToken, userToken string) {
+	t.Helper()
+	adminToken = a.registerUser(t, "admin@test.com", "password123")
+	userToken = a.registerUser(t, "user@test.com", "password123")
+	return adminToken, userToken
+}


### PR DESCRIPTION
- Migration 000003: add role/blocked fields to users, system categories
- User roles (admin/user): first registered user becomes admin
- Admin endpoints: /admin/stats, /admin/users/*, /admin/categories
- Auth middleware: block check + role in context on every request
- GET /auth/me, PATCH /auth/me, POST /auth/me/change-password
- Fix: self-hosted user always gets admin role explicitly
- CORS middleware with allow_all dev mode and origins whitelist
- Integration tests: 47 tests covering auth, admin, and me endpoints